### PR TITLE
[IMP]Pre-sales process: Details for US and MX

### DIFF
--- a/docs/docs/project/pre-sales/general.md
+++ b/docs/docs/project/pre-sales/general.md
@@ -1,54 +1,21 @@
 ---
 layout: post
-title:  How does it work?
-permalink: /docs/project/pre-sales/general
+title:  Introduction
+permalink: /docs/project/pre-sales/intro
 parent: Pre-sales
 grand_parent: Project
 nav_order: 1
 ---
 
 
-# Service
+# Introduction
+A pre-sales is a process for sales prospect that helps to the business advisor to close a sale receiving help from consulting and/or technical team to determine how a use case from the sales prospect can be solved.
 
+### Pre-sale mindset
+Pre-sales is a limit assistance at no cost to help business advisor to close a sale as soon as possible.
 
-# How does the pipe works
-
-
-# Rules
-
-
-
-
-
-- All pre sales requests are managed under project “PSUS - PreSales”.
-  - Project Leader Technical: Ben ([bmu@odoo.com](mailto:bmu@odoo.com))
-  - Project Leader Functional: Massiel ([mac@odoo.com](mailto:mac@odoo.com))
-- Customization and Development is not same at Odoo
-- Get a quote of possible developments early and set expectation in sales
-- All developments will require Odoo.sh
-- Exception is QWeb Reports or MX Addenda Developments
-- Most small business customers do not understand how project management works so setting expectation about lead time, task estimates, timesheet and success pack hours consumption is key and helps in building successful work relation.
-- Some effects of developments on QuickStart project implementation :
-- Slows down QuickStart project implementation
-- Development creates a delay in upgrade
-
-### How to get a quote of development during Pre-Sales
-- Make a copy of the following template task : [[TRIGRAM] Prospect Name : Requirements Short Title (Make copy of this)](https://www.odoo.com/web#id=2260536&cids=3&menu_id=4720&action=333&active_id=3138&model=project.task&view_type=form)
-- Or send a direct email to  “[psus-presales@mail.odoo.com](mailto:psus-presales@mail.odoo.com)”
-- Smart button on sales lead
-- For more information on the Pre-Sales process, [check out this presentation](https://docs.google.com/presentation/d/1xqhNsesJd1UVw26ggFjfk8eCO00sf7S7THUIgi5nvms/edit?usp=sharing)
-
-### What we don’t develop :
-- e-Commerce integration (Odoo does offer OOB eCommerce solution)
-- Connectors to self-hosted systems or home grown/developed systems
-- Any automation that does not save time or does not help improve process when implementing Odoo
-- API Integration for any feature that is available in Odoo
-- Anything that looks like customer’s existing system
-- Debranding (some exception may be allowed) or Backend Theme customization
-- This is not a complete list, integrations may by approved on a case by case basis
-
-### Pre-Sales Estimates
-- Pre-Sales estimates include the time required for development, technical analysis, integration, project management, and functional analysis. - Time is also built in for a reliability ratio on the development hours
+## Pre-Sales Estimates
+- Pre-Sales estimations include the time required for development, technical analysis, integration, project management, and functional analysis. - Time is also built in for a reliability ratio on the development hours
 - This complete estimate sets realistic expectations for project implementation
 - Estimates are calculated [using this spreadsheet](https://docs.google.com/spreadsheets/u/0/d/1waWz4-JIwCi_ogosXXYV8wtamKZiTQwYAYtlb4lFjY8/edit) by the Pre-Sales consultant
 - In certain cases, a lower functional weight may be applied to the estimate if agreed upon by the technical & pre-sales consultants

--- a/docs/docs/project/pre-sales/psmx-presales.md
+++ b/docs/docs/project/pre-sales/psmx-presales.md
@@ -1,0 +1,37 @@
+---
+layout: post
+title:  Pre-Sales MX
+permalink: /docs/project/pre-sales/psmx
+parent: Pre-sales
+grand_parent: Project
+nav_order: 4
+---
+
+# Introduction
+For the Pre-sales process to happen there needs to be two functional experts and one technical expert dedicated to getting the whole estimation done as soon as possible in order to maximize the chances of closing a sale. These specialists sit together in the dedicated area for presales to facilitate the communication between them. Ask your TL for the current seat location.
+
+## Calendar and Location
+The [Presales Calendar](https://docs.google.com/spreadsheets/u/0/d/12nHpa2o0k2BU1pe19L27Ot0eH71ge04GZZHPMLwFlAU/edit) defines the next month’s distribution of the people that will attend the pipe every day. This calendar is planned according to the home office days defined by each member of the Quickstart team that is eligible to do presales and will be filled out by the person in charge of presales. 
+
+## Prerequisites
+When a ticket is moved to the Tech analysis stage in the (PSMX) PRESALES project, there are two requirements that must be met before the estimation process can start: business case, and functional specification. 
+- Business case: In this section, there are two main questions that need to be answered:
+    - WHAT: Explanation of the need of the customer
+    - WHY: Explanation of the reason(s) why you think the feature / customization / development is necessary for the customer.
+- Functional specification: In this section, there are four points that need to be defined:
+    - HOW: Explanation of the way Odoo can handle the business need
+    - AS IS: In the standard solution, where would we change something
+    - TO BE: What’s the expected flow?
+
+- Remarks: Additional remarks that could help clarify business needs or changes in the standard solution.
+
+Also make sure to add the tag **PSMX-TECH** to have a tracking of which tickets had a technical estimation. 
+
+Without this information, the estimation cannot be reliable and in the future could lead to the customers feeling like they were lied to in order to complete the sale and now they need to pay more than what was originally planned. 
+
+## Estimation Process
+Once the ticket is in the correct stage and development specifications are filled out, the technical expert will assign the ticket to themselves (without removing any existing assignees). **If the ticket is assigned to one person, it does not matter if it takes more than a day to complete the task, the responsibility of doing the estimation relies on the person in charge when the ticket was created.** 
+
+The technical expert will figure out the changes that need to be made with a custom module and, based on the [Development Task Estimation](https://docs.google.com/document/d/1sU6sGSkwqwc5IhqtvNoPK-mXLp5VCJ7X__Vr3dlQGP4/edit#heading=h.qyk9ccqcdt9) document will calculate the estimated hours that the customization will take. It is crucial that the [Presales Policies](https://docs.google.com/document/d/1T64WZTtNbe2fpMBV0t3hLLeCYHEbV8M4CmyovhXiuWs/edit#heading=h.957bb2cjpxa9), as well as the [Estimation Policies](https://docs.google.com/document/d/1T64WZTtNbe2fpMBV0t3hLLeCYHEbV8M4CmyovhXiuWs/edit#heading=h.gkro5dqg4xty) are taken into consideration every time an estimation is done. 
+
+Once the process is complete, the technical expert will move the ticket back to the In Progress stage of the project and the functional expert will communicate with the customer the approximate hours and cost for that development. 

--- a/docs/docs/project/pre-sales/psus-presales.md
+++ b/docs/docs/project/pre-sales/psus-presales.md
@@ -1,0 +1,14 @@
+---
+layout: post
+title:  Pre-Sales USA
+permalink: /docs/project/pre-sales/psus
+parent: Pre-sales
+grand_parent: Project
+nav_order: 3
+---
+
+### How to get a quote of development during Pre-Sales
+- Make a copy of the following template task : [[TRIGRAM] Prospect Name : Requirements Short Title (Make copy of this)](https://www.odoo.com/web#id=2260536&cids=3&menu_id=4720&action=333&active_id=3138&model=project.task&view_type=form)
+- Or send a direct email to  “[psus-presales@mail.odoo.com](mailto:psus-presales@mail.odoo.com)”
+- Smart button on sales lead
+- For more information on the Pre-Sales process, [check out this presentation](https://docs.google.com/presentation/d/1xqhNsesJd1UVw26ggFjfk8eCO00sf7S7THUIgi5nvms/edit?usp=sharing)

--- a/docs/docs/project/pre-sales/rules.md
+++ b/docs/docs/project/pre-sales/rules.md
@@ -1,0 +1,33 @@
+---
+layout: post
+title:  Rules
+permalink: /docs/project/pre-sales/rules
+parent: Pre-sales
+grand_parent: Project
+nav_order: 2
+---
+
+# Rules
+- Customization and Development is not same at Odoo
+- Get a quote of possible developments early and set expectation in sales
+- All developments will require Odoo.sh
+- Exception is QWeb Reports or MX Addenda Developments
+- Most small business customers do not understand how project management works so setting expectation about lead time, task estimates, timesheet and success pack hours consumption is key and helps in building successful work relation.
+- Some effects of developments on QuickStart project implementation :
+- Slows down QuickStart project implementation
+- Development creates a delay in upgrade
+
+### What we don’t develop :
+- e-Commerce integration (Odoo does offer OOB eCommerce solution)
+- Connectors to self-hosted systems or home-grown/developed systems
+- Any automation that does not save time or does not help improve process when implementing Odoo
+- API Integration for any feature that is available in Odoo
+- Anything that looks like customer’s existing system
+- Debranding (some exception may be allowed) or Backend Theme customization
+- This is not a complete list, integrations may by approved on a case by case basis
+
+### How to get a quote of development during Pre-Sales
+- Make a copy of the following template task : [[TRIGRAM] Prospect Name : Requirements Short Title (Make copy of this)](https://www.odoo.com/web#id=2260536&cids=3&menu_id=4720&action=333&active_id=3138&model=project.task&view_type=form)
+- Or send a direct email to  “[psus-presales@mail.odoo.com](mailto:psus-presales@mail.odoo.com)”
+- Smart button on sales lead
+- For more information on the Pre-Sales process, [check out this presentation](https://docs.google.com/presentation/d/1xqhNsesJd1UVw26ggFjfk8eCO00sf7S7THUIgi5nvms/edit?usp=sharing)


### PR DESCRIPTION
### Description

I'd like to suggest a new estructure of the pre-sales documentation considering the following order:

- Pre-sales
    - Introduction: What is pre-sales?
    - Rules: What we do and we don't do
    - Process in US
    - Process in MX

In this way, team and other teams can identify every topic easily from a visual point of view and the information of the process for every country is divided into different sections. 
